### PR TITLE
Add testnet wallet checker browser extension

### DIFF
--- a/testnet-wallet-checker/README.md
+++ b/testnet-wallet-checker/README.md
@@ -1,0 +1,10 @@
+# Testnet Wallet Checker
+
+Chrome extension for deriving Bitcoin Testnet and Ethereum Sepolia addresses from a BIP-39 mnemonic and checking their balances.
+
+## Safety Rules
+- **Testnets only**: APIs point to Bitcoin Testnet and Ethereum Sepolia. The extension never contacts mainnet services.
+- **Mnemonic use**: Use only self-generated or public test phrases. Never enter real mainnet phrases.
+- **No mainnet connections**: There are no mainnet API or node URLs in the code.
+
+Load the extension in Chrome via `Extensions → Developer Mode → Load unpacked` and select this folder.

--- a/testnet-wallet-checker/manifest.json
+++ b/testnet-wallet-checker/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "Testnet Wallet Checker",
+  "version": "1.0",
+  "description": "Checks balances for testnet Bitcoin and Ethereum from a BIP-39 phrase.",
+  "permissions": ["activeTab", "storage"],
+  "host_permissions": [
+    "https://api.blockcypher.com/*",
+    "https://api-sepolia.etherscan.io/*"
+  ],
+  "action": {
+    "default_popup": "popup.html"
+  }
+}

--- a/testnet-wallet-checker/popup.html
+++ b/testnet-wallet-checker/popup.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Testnet Wallet Checker</title>
+    <style>
+      textarea { width: 100%; }
+      button { margin-top: 4px; }
+      pre { white-space: pre-wrap; word-break: break-word; }
+    </style>
+  </head>
+  <body>
+    <textarea id="mnemonic" rows="3" placeholder="Enter testnet mnemonic"></textarea>
+    <div>
+      <button id="derive">Check Balances</button>
+      <button id="generate">Generate Test Phrase</button>
+    </div>
+    <pre id="output"></pre>
+
+    <script src="https://cdn.jsdelivr.net/npm/bip39@3.1.0/browser/bip39.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bitcoinjs-lib@6.1.0/dist/bitcoinjs-lib.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/testnet-wallet-checker/popup.js
+++ b/testnet-wallet-checker/popup.js
@@ -1,0 +1,56 @@
+// Testnet Wallet Checker logic
+// Only uses test networks and public test mnemonics.
+
+async function deriveAndDisplay(mnemonic) {
+  const output = document.getElementById('output');
+  output.textContent = '';
+
+  if (!bip39.validateMnemonic(mnemonic)) {
+    output.textContent = 'Invalid mnemonic. Use a valid BIP-39 phrase.';
+    return;
+  }
+
+  const seed = await bip39.mnemonicToSeed(mnemonic);
+
+  // Bitcoin Testnet address using m/44'/1'/0'/0/0
+  const testnet = bitcoin.networks.testnet;
+  const root = bitcoin.bip32.fromSeed(seed, testnet);
+  const child = root.derivePath("m/44'/1'/0'/0/0");
+  const btcAddress = bitcoin.payments.p2pkh({ pubkey: child.publicKey, network: testnet }).address;
+
+  // Ethereum Sepolia address (standard derivation path)
+  const wallet = ethers.Wallet.fromMnemonic(mnemonic);
+  const ethAddress = wallet.address;
+
+  // Fetch balances
+  try {
+    const btcUrl = `https://api.blockcypher.com/v1/btc/test3/addrs/${btcAddress}/balance`;
+    const btcRes = await fetch(btcUrl);
+    const btcJson = await btcRes.json();
+    const btcBalance = btcJson.balance / 1e8; // satoshi to BTC
+
+    const ethUrl = `https://api-sepolia.etherscan.io/api?module=account&action=balance&address=${ethAddress}&tag=latest`;
+    const ethRes = await fetch(ethUrl);
+    const ethJson = await ethRes.json();
+    const ethBalance = ethers.utils.formatEther(ethJson.result);
+
+    output.textContent =
+      `Bitcoin testnet:\n  Address: ${btcAddress}\n  Balance: ${btcBalance} BTC\n\n` +
+      `Ethereum Sepolia:\n  Address: ${ethAddress}\n  Balance: ${ethBalance} ETH`;
+  } catch (err) {
+    output.textContent = 'Error fetching balances: ' + err.message;
+  }
+}
+
+// Event listeners
+
+document.getElementById('derive').addEventListener('click', () => {
+  const mnemonic = document.getElementById('mnemonic').value.trim();
+  deriveAndDisplay(mnemonic);
+});
+
+document.getElementById('generate').addEventListener('click', () => {
+  const mnemonic = bip39.generateMnemonic(128);
+  document.getElementById('mnemonic').value = mnemonic;
+  deriveAndDisplay(mnemonic);
+});


### PR DESCRIPTION
## Summary
- add manifest v3 for testnet wallet checker extension
- implement popup UI for entering mnemonics and viewing balances
- include logic to derive Bitcoin Testnet and Ethereum Sepolia addresses and fetch balances

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689d1e4bff008322922279f44117fd2d